### PR TITLE
Implement folder upload

### DIFF
--- a/src/directives/dropzone.directive.ts
+++ b/src/directives/dropzone.directive.ts
@@ -78,7 +78,8 @@ export class NgxDragAndDropDirective implements OnInit {
         if (!transfer) {
             return;
         }
-        if (this.dropOptions.folderAccept == true)
+        // Not support IE (folder upload)
+        if (this.dropOptions.folderAccept == true && NgxDragAndDropDirective.getVersionOfIE() == -1)
         {
             this.getFilesWebkitDataTransferItems(transfer.items).then(
                 (data : File[])=>{
@@ -137,7 +138,26 @@ export class NgxDragAndDropDirective implements OnInit {
     }
 
 
+    private static getVersionOfIE() { 
+        var word; 
+        var agent = navigator.userAgent.toLowerCase(); 
+   
+        // IE old version ( IE 10 or Lower ) 
+        if ( navigator.appName == "Microsoft Internet Explorer" ) word = "msie "; 
 
+        // IE 11 
+        else if ( agent.search( "trident" ) > -1 ) word = "trident/.*rv:"; 
+
+        // Microsoft Edge
+        else if ( agent.search( "edge/" ) > -1 ) word = "edge/"; 
+
+        else return -1; 
+   
+        var reg = new RegExp( word + "([0-9]{1,})(\\.{0,}[0-9]{0,1})" ); 
+        if (reg.exec( agent ) != null) 
+            return parseFloat( RegExp.$1 + RegExp.$2 ); 
+        return -1; 
+   }
 
     private getFilesWebkitDataTransferItems(dataTransferItems) {
         function traverseFileTreePromise(item, path='') {

--- a/src/services/abstractUpload.service.ts
+++ b/src/services/abstractUpload.service.ts
@@ -33,7 +33,7 @@ export abstract class AbstractUploadService {
   /**
    * Adds files to the queue
    */
-  addToQueue(files: FileList, formGroup: FormGroup | null, dropOptions?: DropTargetOptions) {
+  addToQueue(files: File[], formGroup: FormGroup | null, dropOptions?: DropTargetOptions) {
 
     this.logger.info('add to queue');
 
@@ -46,8 +46,8 @@ export abstract class AbstractUploadService {
     }
 
     for (let i = 0; i < files.length; i++) {
-      const file = files.item(i)!;
-      this.logger.debug(files.item(i));
+      const file = files[i]!;
+      this.logger.debug(files[i]);
 
       if (dropOptions && dropOptions.accept) {
         const accepted = dropOptions.accept.some((type: string) => type === file.type);

--- a/src/services/fileItem.model.ts
+++ b/src/services/fileItem.model.ts
@@ -21,6 +21,12 @@ export class FileItem {
     constructor(public file: File, private uploadService: AbstractUploadService, protected logger: NgxUploadLogger) {
     }
 
+    public get filePath() : string
+    {
+        var file : any = this.file;
+        return file.filePath != undefined ? file.filePath : file.name;
+    }
+
     upload(endpoint: UploadEndPoint, options?: any) {
         if (endpoint) {
             this.uploadService.uploadFileItem(this, endpoint, options);

--- a/src/utils/configuration.model.ts
+++ b/src/utils/configuration.model.ts
@@ -13,7 +13,8 @@ export interface DropTargetOptions {
   colorDrop: string,
   accept?: MineTypeEnum[],
   capture?: 'user' | 'environment',
-  multiple?: boolean
+  multiple?: boolean,
+  folderAccept?: boolean
 }
 
 export interface LoggerOptions {


### PR DESCRIPTION
Folder uploading was only applied to NgxDragAndDropDirective.

It does not work in IE because of limitations of web browsers.

Users need to setting DroptargetOptions.folderAccept
<pre>
export const ngxDropTargetOptions: DropTargetOptions = {
    color: 'dropZoneColor',
    colorDrag: 'dropZoneColorDrag',
    colorDrop: 'dropZoneColorDrop',
    multiple: true,
    folderAccept: true
};
</pre>

2. If you want to get path of file, use <code>item.filePath</code>
<pre>
var item : FileItem = ...
console.log(item.filePath);
</pre>

