### PR TITLE
Fix disableMultipart option of HTTPClientUpload

### DIFF
--- a/src/services/fileItem.model.ts
+++ b/src/services/fileItem.model.ts
@@ -12,7 +12,6 @@ export class FileItem {
     isError: boolean;
     progress = 0;
 
-    disableMultipart: boolean = false;
     formData: FormData = new FormData();
 
     alias = 'file';

--- a/src/services/fileItem.model.ts
+++ b/src/services/fileItem.model.ts
@@ -12,6 +12,7 @@ export class FileItem {
     isError: boolean;
     progress = 0;
 
+    disableMultipart: boolean = false;
     formData: FormData = new FormData();
 
     alias = 'file';

--- a/src/services/httpClientUpload.service.ts
+++ b/src/services/httpClientUpload.service.ts
@@ -39,8 +39,15 @@ export class HttpClientUploadService extends AbstractUploadService {
 
         item.uploadInProgress = true;
 
-        const sendable = item.formData;
-        sendable.append(item.alias, item.file, item.file.name);
+        var sendable;
+
+        if (item.disableMultipart == true)
+            sendable = item.file;
+        else
+        {
+            sendable = item.formData;
+            sendable.append(item.alias, item.file, item.file.name);
+        }
 
         const req = new HttpRequest(method, url, sendable, Object.assign(options, {reportProgress: true}));
 

--- a/src/services/httpClientUpload.service.ts
+++ b/src/services/httpClientUpload.service.ts
@@ -41,12 +41,14 @@ export class HttpClientUploadService extends AbstractUploadService {
 
         var sendable;
 
-        if (item.disableMultipart == true)
-            sendable = item.file;
-        else
+        if (!this.disableMultipart)
         {
             sendable = item.formData;
             sendable.append(item.alias, item.file, item.file.name);
+        }
+        else
+        {
+            sendable = item.file;
         }
 
         const req = new HttpRequest(method, url, sendable, Object.assign(options, {reportProgress: true}));


### PR DESCRIPTION
The disableMultipart option is existed in 'HTTPClientUpload' class.

But, this option did not working in the 'HTTPClientUpload'.

So I fixed it.