### PR TITLE
Clear the previously uploaded input value

### DIFF
--- a/src/components/inputfile.component.ts
+++ b/src/components/inputfile.component.ts
@@ -37,6 +37,8 @@ export class InputfileComponent implements AfterViewInit {
 
   onFilesAdded() {
     this.uploader.addToQueue(this.file.nativeElement.files, this.formGroup);
+    // Clear the previous input value
+    this.file.nativeElement.value = '';
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
- This will clear/reset the filename (value) of the input allowing the same image to be added back if removed by mistake
- This will also accept multiple instances of the same image (just in case you need to)