### PR TITLE
Remove HttpClientModule to avoid LazyLoaded module conflicts

### DIFF
--- a/src/ngx-upload.module.ts
+++ b/src/ngx-upload.module.ts
@@ -49,14 +49,14 @@ export function createNgxUploadRootGuard(options: LoggerOptions) {
   exports: [
     ...ngxDeclarations
   ],
-  imports: [ HttpClientModule ],
+  imports: [],
   entryComponents: [InputfileComponent]
 })
 
 export class NgxUploadModule {
 
   static forRoot(dropTargetOptions?: DropTargetOptions,
-                 loggerOptions?: LoggerOptions): ModuleWithProviders {
+    loggerOptions?: LoggerOptions): ModuleWithProviders {
 
     return {
       ngModule: NgxUploadModule,


### PR DESCRIPTION
HttpClientModule added in `ngx-upload.module.ts` resets the `HTTP_INTERCEPTORS` from app module if added in child/lazyloaded modules.